### PR TITLE
Add emp skills route

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -36,6 +36,52 @@ module.exports = function(app) {
         });
     });
 
+    // Get the list of skill_data rows from a role_id via
+    // the job_skills.  a.k.a.  a join.
+    app.get("api/skill_data/role/:role_id", function(req, res) {
+        db.Job_skills.findAll({
+            where: {
+                role_id: req.params.role_id
+            }
+        }).then(function(dbJob_skills) {
+            var dbSkill_data;
+            dbJob_skills.forEach(job_skills_row => {
+                db.Skill_data.findOne({
+                    where: {
+                        id: job_skills_row.skill_data_id
+                    }
+                }).then(function(dbSkill_data_row) {
+                    dbSkill_data.push(dbSkill_data_row);
+                });
+            });
+            res.json(dbSkill_data);
+        });
+    })
+
+    // Get the list of skill_data rows from an empolyees_id + reviewer_id via
+    // the job_skills.  a.k.a.  a join.
+    app.get("api/skill_data/employee/:emp_id/:rev_id", function(req, res) {
+        db.Emp_skills.findAll({
+            where: {
+                employees_id: req.params.emp_id,
+                reviewer_id: req.params.rev_id
+            }
+        }).then(function(dbEmp_skills) {
+            var dbSkill_data;
+            dbEmp_skills.forEach(emp_skills_row => {
+                db.Skill_data.findOne({
+                    where: {
+                        id: emp_skills_row.skill_data_id
+                    }
+                }).then(function(dbSkill_data_row) {
+                    dbSkill_data.push(dbSkill_data_row);
+                });
+            });
+            res.json(dbSkill_data);
+        });
+    })
+
+
     // Add and row to the skill_data table
     app.post("/api/skill_data", function(req, res) {
         db.Skill_data.create({
@@ -93,6 +139,8 @@ module.exports = function(app) {
     });
 
     // Route for getting some data about our employees to be used client side
+    // this route does not currently return much of anything. -msm
+    // I question its purpose.
     app.get("/api/employees_data", function(req, res) {
         if (!req.user) {
             // The employee is not logged in, send back an empty object
@@ -133,14 +181,21 @@ module.exports = function(app) {
         });
     });
 
-    //find all employees with a specific job title.  (using the roles database)
+    //find all employees with a specific job title.  (using the role table)
     app.get("/api/role/:r_title", function(req, res) {
-        db.Role.findAll({
+        db.Role.findOne({
             where: {
                 r_title: req.params.r_title
             }
         }).then(function(dbRole) {
-            res.json(dbRole);
+            db.Employees.findAll({
+                where: {
+                    role_id: dbRole.id
+                }
+            }).then(function(dbEmployees) {
+                res.json(dbEmployees);
+            });
+
         });
     });
 

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -130,6 +130,25 @@ module.exports = function(app) {
     });
 
 
+    // create and entry for emp_skills
+    // this will link a skill_data row to an employees row
+    app.post("/api/emp_skills", function(req, res) {
+        db.Emp_skills.create({
+                current_level: req.body.current_level,
+                employees_id: req.body.employees_id,
+                reviewer_id: req.body.reviewer_id,
+                skill_data_id: req.body.skill_data_id
+            })
+            .then(function() {
+                res.json({});
+            })
+            .catch(function(err) {
+                res.status(401).json(err);
+            });
+    });
+
+
+
 
 
     // Route for logging employees out


### PR DESCRIPTION
Added the post route: /api/emp_skills, which needs an object containing: current_level, employees_id, reviewer_id, and skill_data_id.   If given those, it will cause an employees row to be connected to a skill_data row with the added data of 'current_level'.  Note that the reviewer_id is a necessary piece of data that (if not done) could potentially break our ability to read THIS record back out.